### PR TITLE
Update README.md to indicate this is no longer a test repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-This is a test repository to experiment with GitHub's "privately reporting a
-security vulnerability" workflow, see
-<https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability>
-
-If or when security vulnerabilities or advisories appear against this specific
-repository, they are expected to be as a result of experimenting with this
-workflow and not be actual vulnerabilities.
+This repository exists to enable reporting of LLVM security issues to the [LLVM
+security group](https://llvm.org/docs/Security.html) using GitHub's "privately
+reporting a security vulnerability" workflow, see
+<https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability>.


### PR DESCRIPTION
This is part of migrating security issue reporting from chromium.org to github's mechanism.
I hope to find time soon to also make the necessary changes to the main monorepo updating the documentation to let people know to report security issue using github's mechanism rather than using chromium.org