### PR TITLE
[email-rotation] automatically add rotation(s)

### DIFF
--- a/email-rotation/rotation.yaml
+++ b/email-rotation/rotation.yaml
@@ -42,3 +42,11 @@ rotations:
   - tuliom
   - wphuhn-intel
   start_time: '2025-12-21T00:00:00+00:00'
+- members:
+  - yroux
+  - ahmedbougacha
+  start_time: '2026-01-04T00:00:00+00:00'
+- members:
+  - mrragava
+  - DimitryAndric
+  start_time: '2026-01-18T00:00:00+00:00'


### PR DESCRIPTION
This updates rotations with the result of running
`./email-rotation/extend_rotation.py --ensure-weeks=16`.
