### PR TITLE
[email-rotation] automatically add rotation(s)

### DIFF
--- a/email-rotation/rotation.yaml
+++ b/email-rotation/rotation.yaml
@@ -102,3 +102,11 @@ rotations:
   - ormris
   - ojhunt
   start_time: '2026-07-19T00:00:00+00:00'
+- members:
+  - smithp35
+  - pietroalbini
+  start_time: '2026-08-02T00:00:00+00:00'
+- members:
+  - serge-sans-paille
+  - offsake
+  start_time: '2026-08-16T00:00:00+00:00'


### PR DESCRIPTION
This updates rotations with the result of running
`./email-rotation/extend_rotation.py --ensure-weeks=16`.
