### PR TITLE
Advisory footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Please follow these guidelines when submitting a report:
 
   - `I-have-reviewed-SECURITY-md`: This is a self-certification that you have
     read and understood [LLVM's `SECURITY.md`](https://github.com/llvm/llvm-project/blob/main/SECURITY.md)
-    and the [LLVM security documentation](https://llvm.org/docs/Security.html).
-    Many LLVM binaries do **not** consider most bugs, including crashes, memory
-    corruption, etc, to be security vulnerabilities.
+    and the [LLVM security documentation on what is a security
+    issue](https://llvm.org/docs/Security.html#what-is-considered-a-security-issue).
+    Notably, many LLVM binaries do **not** consider most bugs, including
+    crashes, memory corruption, etc, to be security vulnerabilities.
   - `I-used-AI-in-this-report`: This is a self-certification about whether AI
     or tool-generated content was a significant contributor to your report. If
     this is `yes`, you **must** read and comply with the [LLVM AI Tool Use

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Please follow these guidelines when submitting a report:
 
   - `I-have-reviewed-SECURITY-md`: This is a self-certification that you have
     read and understood [LLVM's `SECURITY.md`](https://github.com/llvm/llvm-project/blob/main/SECURITY.md)
-    and the [LLVM security documentation on what is a security
+    and the [LLVM security documentation on what constitutes a security
     issue](https://llvm.org/docs/Security.html#what-is-considered-a-security-issue).
     Notably, many LLVM binaries do **not** consider most bugs, including
-    crashes, memory corruption, etc, to be security vulnerabilities.
+    crashes, memory corruption, etc., to be security vulnerabilities.
   - `I-used-AI-in-this-report`: This is a self-certification about whether AI
     or tool-generated content was a significant contributor to your report. If
     this is `yes`, you **must** read and comply with the [LLVM AI Tool Use

--- a/README.md
+++ b/README.md
@@ -2,3 +2,32 @@ This repository exists to enable reporting of LLVM security issues to the [LLVM
 security group](https://llvm.org/docs/Security.html) using GitHub's "privately
 reporting a security vulnerability" workflow, see
 <https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability>.
+
+Unfortunately, due to the volume of reports we've received that have not
+met community standards, we are requiring the addition of two footers to each
+security report:
+
+- `I-have-reviewed-SECURITY-md`: this is a self-certification that you have
+  read and understood our [SECURITY.md](SECURITY.md) (and, more importantly,
+  the LLVM `SECURITY.md` linked from it). Many LLVM binaries do **not** consider
+  most bugs, including crashes, to be security vulnerabilities.
+- `I-used-an-LLM-in-generating-this-report`: this is a self-certification about
+  whether an LLM was a significant contributor to your report. If this is
+  `yes`, it is **also** a self-certification that you have read and understood
+  the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). If
+  this is `no`, you are certifying that LLMs were not a significant contributor
+  to the report, and you needn't read the policy.
+
+These should be placed at the bottom of your report, and formatted like so:
+
+```
+I-have-reviewed-SECURITY-md: yes
+I-used-an-LLM-in-generating-this-report: yes
+```
+
+These are not machine parsed; feel free to add commentary beyond yes|no if you
+feel it's appropriate. Please keep the names consistent though - they're meant
+to be easy to ctrl+f for.
+
+**If your report lacks these**, we are likely to ask you to add them before we
+read your report.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ I-have-reviewed-SECURITY-md: yes
 I-used-an-LLM-in-generating-this-report: yes
 ```
 
-These are not machine parsed; feel free to add commentary beyond yes|no if you
-feel it's appropriate. Please keep the names consistent though - they're meant
-to be easy to ctrl+f for.
+These are not machine parsed; feel free to add commentary beyond `yes|no` if
+you feel it's appropriate. Please keep the names consistent though - they're
+meant to be easy to ctrl+f for.
 
 **If your report lacks these**, we will ask you to add them before we read your
 report.

--- a/README.md
+++ b/README.md
@@ -3,31 +3,43 @@ security group](https://llvm.org/docs/Security.html) using GitHub's "privately
 reporting a security vulnerability" workflow, see
 <https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability>.
 
-Unfortunately, due to the volume of reports we've received that have not
-met community standards, we are requiring the addition of two footers to each
-security report:
+Please follow these guidelines when submitting a report:
 
-- `I-have-reviewed-SECURITY-md`: this is a self-certification that you have
-  read and understood our [SECURITY.md](SECURITY.md) (and, more importantly,
-  the LLVM `SECURITY.md` linked from it). Many LLVM binaries do **not** consider
-  most bugs, including crashes, to be security vulnerabilities.
-- `I-used-an-LLM-in-generating-this-report`: this is a self-certification about
-  whether an LLM was a significant contributor to your report. If this is
-  `yes`, it is **also** a self-certification that you have read and understood
-  the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). If
-  this is `no`, you are certifying that LLMs were not a significant contributor
-  to the report, and you needn't read the policy.
+- Open separate security advisories for separate reports. Do not group multiple
+  unrelated issues into a single report.
+- Due to the volume of reports we've received that have not met community
+  standards, we require the addition of two footers at the end of every
+  security report:
+
+  - `I-have-reviewed-SECURITY-md`: This is a self-certification that you have
+    read and understood [LLVM's `SECURITY.md`](https://github.com/llvm/llvm-project/blob/main/SECURITY.md)
+    and the [LLVM security documentation](https://llvm.org/docs/Security.html).
+    Many LLVM binaries do **not** consider most bugs, including crashes, memory
+    corruption, etc, to be security vulnerabilities.
+  - `I-used-AI-in-this-report`: This is a self-certification about whether AI
+    or tool-generated content was a significant contributor to your report. If
+    this is `yes`, you **must** read and comply with the [LLVM AI Tool Use
+    Policy](https://llvm.org/docs/AIToolPolicy.html), and you must clearly state
+    how the tool-generated content was used (for example, by listing the tools
+    used and the extent of their contribution). If this is `no`, you are
+    certifying that AI/tool-generated content was not a significant contributor
+    to the report.
 
 These should be placed at the bottom of your report, and formatted like so:
 
 ```
 I-have-reviewed-SECURITY-md: yes
-I-used-an-LLM-in-generating-this-report: yes
+I-used-AI-in-this-report: no
 ```
 
-These are not machine parsed; feel free to add commentary beyond `yes|no` if
-you feel it's appropriate. Please keep the names consistent though - they're
-meant to be easy to ctrl+f for.
+Or, if you used AI:
+
+```
+I-have-reviewed-SECURITY-md: yes
+I-used-AI-in-this-report: yes; Claude originally flagged the bug, I validated it and wrote this disclosure.
+```
+
+If in doubt whether your AI use is significant, tend toward yes.
 
 **If your report lacks these**, we will ask you to add them before we read your
 report.

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ These are not machine parsed; feel free to add commentary beyond yes|no if you
 feel it's appropriate. Please keep the names consistent though - they're meant
 to be easy to ctrl+f for.
 
-**If your report lacks these**, we are likely to ask you to add them before we
-read your report.
+**If your report lacks these**, we will ask you to add them before we read your
+report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,6 @@
 
 This repository is for reporting security issues with LLVM.
 
-Please see
-[LLVM's `SECURITY.md` here](https://github.com/llvm/llvm-project/blob/main/SECURITY.md)
-for more information on how to report an issue, and what is considered a
-security issue.
-
-Please see [README.md](README.md) for information on footers that must be part
-of every security advisory. If a report does not have these, we will ask you to
-add them before considering your report.
+**Please see [README.md](README.md)** for pointers on how to file your report.
+There are very important guidelines there; if they are not followed, we will
+ask you to follow them before reviewing your report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,3 +6,7 @@ Please see
 [LLVM's `SECURITY.md` here](https://github.com/llvm/llvm-project/blob/main/SECURITY.md)
 for more information on how to report an issue, and what is considered a
 security issue.
+
+Please see [README.md](README.md) for information on footers that must be part
+of every security advisory. If a report does not have these, we will ask you to
+add them before considering your report.


### PR DESCRIPTION
We've historically gotten quite a few reports that are not security
advisories. Given the influx of recent not-a-security-advisory reports,
it seems best to raise the bar here a bit for contributors.

The idea is that if someone accidentally forgets these, we just politely
ask them to review the README and follow up when they're ready.
