### PR TITLE
email-rotation: remove cuviper

### DIFF
--- a/email-rotation/rotation-members.yaml
+++ b/email-rotation/rotation-members.yaml
@@ -10,7 +10,6 @@ members:
   - DimitryAndric
   - emaste
   - gburgessiv
-  - cuviper
   - kbeyls
   - mmdriley
   - ormris

--- a/email-rotation/rotation.yaml
+++ b/email-rotation/rotation.yaml
@@ -92,7 +92,7 @@ rotations:
   start_time: '2026-06-07T00:00:00+00:00'
 - members:
   - gburgessiv
-  - cuviper
+  - tuliom
   start_time: '2026-06-21T00:00:00+00:00'
 - members:
   - kbeyls
@@ -114,7 +114,3 @@ rotations:
   - GreatKeeper
   - tpenge
   start_time: '2026-08-30T00:00:00+00:00'
-- members:
-  - tuliom
-  - ahmedbougacha
-  start_time: '2026-09-13T00:00:00+00:00'


### PR DESCRIPTION
As requested in https://github.com/llvm/llvm-project/pull/203061

cuviper's on the current rotation (ending in a few days) and isn't scheduled for future ones, so no need to touch that schedule.