### PR TITLE
[email-rotation] automatically add rotation(s)

### DIFF
--- a/email-rotation/rotation.yaml
+++ b/email-rotation/rotation.yaml
@@ -114,3 +114,15 @@ rotations:
   - GreatKeeper
   - tpenge
   start_time: '2026-08-30T00:00:00+00:00'
+- members:
+  - cuviper
+  - ahmedbougacha
+  start_time: '2026-09-13T00:00:00+00:00'
+- members:
+  - wphuhn-intel
+  - mrragava
+  start_time: '2026-09-27T00:00:00+00:00'
+- members:
+  - yroux
+  - DimitryAndric
+  start_time: '2026-10-11T00:00:00+00:00'


### PR DESCRIPTION
This updates rotations with the result of running
`./email-rotation/extend_rotation.py --ensure-weeks=16`.
