### PR TITLE
email-rotation: fix rotation assignment logic

### DIFF
--- a/email-rotation/extend_rotation.py
+++ b/email-rotation/extend_rotation.py
@@ -27,13 +27,16 @@ def find_most_recent_service_times(
         service_time = rotation.start_time
         for member in rotation.members:
             # `rotations` is always in the order of oldest to newest, so we can
-            # just overwrite old values here.
-            last_service_times[member] = service_time
+            # just overwrite old values here. Only record service times for
+            # members currently in the rotation.
+            if member in last_service_times:
+                last_service_times[member] = service_time
 
     return last_service_times
 
 
 def generate_additional_rotations(
+    *,
     prior_rotations: list[rotations.Rotation],
     members: list[str],
     rotation_length_weeks: int,
@@ -207,10 +210,10 @@ def main() -> None:
         num_rotations_to_add = 5
 
     rotation_generator = generate_additional_rotations(
-        current_rotation.rotations,
-        members_file.members,
-        people_per_rotation,
-        rotation_length_weeks,
+        prior_rotations=current_rotation.rotations,
+        members=members_file.members,
+        rotation_length_weeks=rotation_length_weeks,
+        people_per_rotation=people_per_rotation,
         now=now,
     )
 

--- a/email-rotation/extend_rotation_test.py
+++ b/email-rotation/extend_rotation_test.py
@@ -63,6 +63,21 @@ class TestFindMostRecentServiceTimes(unittest.TestCase):
         }
         self.assertEqual(result, expected)
 
+    def test_removed_members_ignored(self) -> None:
+        members = ["alice", "bob"]
+        time1 = datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc)
+        time2 = datetime.datetime(2023, 1, 15, tzinfo=datetime.timezone.utc)
+        prior_rotations = [
+            Rotation(start_time=time1, members=["alice", "bob"]),
+            Rotation(start_time=time2, members=["charlie", "alice"]),
+        ]
+        result = find_most_recent_service_times(prior_rotations, members)
+        expected = {
+            "alice": time2,
+            "bob": time1,
+        }
+        self.assertEqual(result, expected)
+
 
 class TestCalculateRotationsToCover(unittest.TestCase):
     def test_no_existing_rotations_raises_error(self) -> None:
@@ -133,7 +148,11 @@ class TestGenerateAdditionalRotations(unittest.TestCase):
 
         # The function returns an Iterator[Rotation]
         generator = generate_additional_rotations(
-            [], members, rotation_length_weeks, people_per_rotation, now=MOCKED_NOW_UTC
+            prior_rotations=[],
+            members=members,
+            rotation_length_weeks=rotation_length_weeks,
+            people_per_rotation=people_per_rotation,
+            now=MOCKED_NOW_UTC,
         )
         generated_list = [next(generator) for _ in range(2)]
 
@@ -158,10 +177,10 @@ class TestGenerateAdditionalRotations(unittest.TestCase):
         people_per_rotation = 1
 
         generator = generate_additional_rotations(
-            prior_rotations,
-            members,
-            rotation_length_weeks,
-            people_per_rotation,
+            prior_rotations=prior_rotations,
+            members=members,
+            rotation_length_weeks=rotation_length_weeks,
+            people_per_rotation=people_per_rotation,
             now=MOCKED_NOW_UTC,
         )
         generated_list = [next(generator) for _ in range(3)]


### PR DESCRIPTION
The auto-update in #19 had to be reverted due to readding cuviper. The function for determining new rotations wasn't properly filtering out removed members.

While I'm here, I noticed a few args were flipped. Force kwargs for the callee so that's easier to spot in the future.

Tested by running the update-rotation script, no new cuviper rotations